### PR TITLE
Quickfix to make tests compile

### DIFF
--- a/driver/rsync/http_server_test.go
+++ b/driver/rsync/http_server_test.go
@@ -17,11 +17,11 @@ func TestNormalHttpCopy(t *testing.T) {
 		os.Args[0], "http_server.go", "../scheduler/scheduler.go", "fetch_url.go",
 	}
 
-	rsyncServer, err := NewRsyncServer(":0", files[0], files[1:])
+	rsyncServer, err := NewRsyncServer(files[0], files[1:])
 	if err != nil {
 		t.Fatalf("Failed to start local server: %v", err)
 	}
-	rsyncServer.Start()
+	rsyncServer.StartRsyncServer(nil, ":0")
 
 	err = FetchFilesTo(fmt.Sprintf("localhost:%d", rsyncServer.Port), "/tmp")
 	if err != nil {


### PR DESCRIPTION
Last commits broke the `http_server_test.go`.