### PR TITLE
Fixes adjusting arguments passed to executor

### DIFF
--- a/agent/agent_server_executor_start.go
+++ b/agent/agent_server_executor_start.go
@@ -68,6 +68,8 @@ func (as *AgentServer) handleStart(conn net.Conn,
 }
 
 func (as *AgentServer) adjustArgs(args []string, requestId uint32) (ret []string) {
+	ret = []string{"-glow.request.id", fmt.Sprintf("%d", requestId)}
+
 	if as.Option.CertFiles.IsEnabled() {
 		var cleanedArgs []string
 		for _, arg := range args {
@@ -92,10 +94,8 @@ func (as *AgentServer) adjustArgs(args []string, requestId uint32) (ret []string
 			}
 		}
 	} else {
-		ret = args
+		ret = append(ret, args...)
 	}
-	ret = append(ret, "-glow.request.id")
-	ret = append(ret, fmt.Sprintf("%d", requestId))
 
 	// fmt.Printf("cmd: %v\n", ret)
 	return


### PR DESCRIPTION
It is not guaranteed that the cmd arguments will be correctly parsed
when the glow framework adds a new argument to the end of the arguments.

Glow's specific arguments should be always flags and should be before
program's arguments, because the program can have both flag arguments and
non-flag arguments. That can cause problems because Golang won't
parse flags as flag arguments that are after a non-flag arguments.

Example:

`-glow.flag1 -glow.flag2 other_argument -glow.flag3`

the glow.flag3 is not parsed as a flag argument