### PR TITLE
Move pickedServerChan definition before where it is used

### DIFF
--- a/driver/scheduler/scheduler_events.go
+++ b/driver/scheduler/scheduler_events.go
@@ -35,7 +35,6 @@ func (s *Scheduler) EventLoop() {
 		case SubmitTaskGroup:
 			// fmt.Printf("processing %+v\n", event)
 			taskGroup := event.TaskGroup
-			pickedServerChan := make(chan market.Supply, 1)
 			go func() {
 				defer event.WaitGroup.Done()
 				tasks := event.TaskGroup.Tasks
@@ -44,6 +43,7 @@ func (s *Scheduler) EventLoop() {
 				s.shardLocator.waitForInputDatasetShardLocations(tasks[0])
 				// fmt.Printf("inputs of %s is %s\n", tasks[0].Name(), s.allInputLocations(tasks[0]))
 
+				pickedServerChan := make(chan market.Supply, 1)
 				s.Market.AddDemand(market.Requirement(taskGroup), event.Bid, pickedServerChan)
 
 				// get assigned executor location

--- a/flow/dataset_map_test.go
+++ b/flow/dataset_map_test.go
@@ -68,11 +68,9 @@ func TestCoGroupMap(t *testing.T) {
 
 	outChan := make(chan result, 0)
 	cogroup_result.AddOutput(outChan)
-	t.Log("Starting cogroup_result.Run()")
 	go cogroup_result.Run()
 
 	got := make([]result, 0, 2)
-	t.Log("Collecting result")
 	for item := range outChan {
 		got = append(got, item)
 	}

--- a/flow/dataset_map_test.go
+++ b/flow/dataset_map_test.go
@@ -68,9 +68,11 @@ func TestCoGroupMap(t *testing.T) {
 
 	outChan := make(chan result, 0)
 	cogroup_result.AddOutput(outChan)
+	t.Log("Starting cogroup_result.Run()")
 	go cogroup_result.Run()
 
 	got := make([]result, 0, 2)
+	t.Log("Collecting result")
 	for item := range outChan {
 		got = append(got, item)
 	}


### PR DESCRIPTION
This helps reduces the mental effort to recognize the fact that
the variable is not used elsewhere.