### PR TITLE
Remove freebsd and use 2 most recent go releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,9 @@ os:
   - linux
   - osx
   - windows
-  - freebsd
 
 language: go
-go: 
- - 1.5
+go:
  - 1.6
  - tip
 


### PR DESCRIPTION
This reduces Travis build time; also does not affect much of the testing and build coverage.